### PR TITLE
Update make_response to support additional data types

### DIFF
--- a/odoo-stubs/http.pyi
+++ b/odoo-stubs/http.pyi
@@ -255,7 +255,7 @@ class Request:
     def get_json_data(self): ...
     def make_response(
         self,
-        data: str,
+        data: str | bytes | bytearray | None,
         headers: list[tuple[str, Any]] | None = ...,
         cookies: Mapping | None = ...,
         status: int = ...,


### PR DESCRIPTION
Extended the data parameter to accept bytes, bytearray, or None in addition to strings. This ensures greater flexibility and compatibility for response creation.

The parent function in werkzeug seems to support this.  It seems like it might support Any, but I'm not a fan of that.  

`        if response is None:
            self.response = []
        elif isinstance(response, (str, bytes, bytearray)):
            self.set_data(response)
        else:
            self.response = response`